### PR TITLE
feat: demo mpa

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "license": "ISC",
       "workspaces": [
         "packages/webpack-adv",
-        "packages/vite-adv"
+        "packages/vite-adv",
+        "packages/demo"
       ],
       "devDependencies": {
         "prettier": "^3.5.3",
@@ -591,6 +592,10 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@lbd/demo": {
+      "resolved": "packages/demo",
+      "link": true
     },
     "node_modules/@lbd/vite-adv": {
       "resolved": "packages/vite-adv",
@@ -3322,11 +3327,13 @@
         "node": ">=6"
       }
     },
-    "packages/a": {
-      "name": "@lbd/a",
+    "packages/demo": {
+      "name": "@lbd/demo",
       "version": "1.0.0",
-      "extraneous": true,
-      "license": "ISC"
+      "license": "ISC",
+      "devDependencies": {
+        "vite": "^6.3.5"
+      }
     },
     "packages/vite-adv": {
       "name": "@lbd/vite-adv",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "homepage": "https://github.com/pengVc/learning-by-doing#readme",
   "workspaces": [
     "packages/webpack-adv",
-    "packages/vite-adv"
+    "packages/vite-adv",
+    "packages/demo"
   ],
   "devDependencies": {
     "prettier": "^3.5.3",

--- a/packages/demo/.gitignore
+++ b/packages/demo/.gitignore
@@ -1,0 +1,24 @@
+# Logs
+logs
+*.log
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+lerna-debug.log*
+
+node_modules
+dist
+dist-ssr
+*.local
+
+# Editor directories and files
+.vscode/*
+!.vscode/extensions.json
+.idea
+.DS_Store
+*.suo
+*.ntvs*
+*.njsproj
+*.sln
+*.sw?

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "@lbd/demo",
+  "version": "1.0.0",
+  "main": "index.js",
+  "devDependencies": {
+    "vite": "^6.3.5"
+  },
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "description": ""
+}

--- a/packages/demo/src/pages/eval/index.html
+++ b/packages/demo/src/pages/eval/index.html
@@ -3,5 +3,18 @@
   <body>
     <div id="app">eval Page</div>
     <script type="module" src="./main.ts"></script>
+    <script>
+      unStrictMode()
+
+      function unStrictMode() {
+        try {
+          eval('var foo = 1')
+
+          console.log('unStrictMode: ', foo) // => 1
+        } catch (err) {
+          console.log('unStrictMode err: ', err)
+        }
+      }
+    </script>
   </body>
 </html>

--- a/packages/demo/src/pages/eval/index.html
+++ b/packages/demo/src/pages/eval/index.html
@@ -1,0 +1,7 @@
+<!doctype html>
+<html>
+  <body>
+    <div id="app">eval Page</div>
+    <script type="module" src="./main.ts"></script>
+  </body>
+</html>

--- a/packages/demo/src/pages/eval/main.ts
+++ b/packages/demo/src/pages/eval/main.ts
@@ -1,5 +1,92 @@
-const main = () => {
-  console.log('hello eval')
+// @ts-nocheck
+
+window.x = 'global'
+
+/**
+ * 直接调用 eval
+ */
+function directEval() {
+  'use strict'
+  var x = 'local'
+
+  // local
+  // 可以解析当前(调用 eval 的)作用域的变量
+  console.log('directEval: ', eval('x')) // => 'local'
+}
+directEval()
+
+/**
+ * 间接调用 eval
+ */
+function indirectEval() {
+  'use strict'
+  var x = 'local'
+
+  // 非直接调用 eval 的几种方式
+  console.log('indirectEval: ', eval.call(null, 'x')) // => 'global'
+  console.log('indirectEval: ', window.eval('x')) // => 'global'
+  console.log('indirectEval: ', (1, eval)('x')) // => 'global'
+  var aliasEval = eval
+  console.log('indirectEval: ', aliasEval('x')) // => 'global'
+
+  aliasEval('var _foo = 3')
+  console.log('indirectEval: ', window._foo) // => 3
+
+  var obj = { eval: eval }
+  console.log('indirectEval: ', obj.eval('x')) // => global
+}
+indirectEval()
+
+function newFnWithDeclare() {
+  var foo
+  var fn = new Function('var foo = 1')
+
+  fn()
+  // `undefined` 因为 Function 构造函数创造的变量 foo 并不在全局范围内!
+  console.log('new Function (with declare): ', typeof foo) // => undefined
+
+  if (typeof window !== 'undefined') {
+    console.log('new Function (with declare): ', window.foo) // => undefined
+  } else if (typeof global !== 'undefined') {
+    console.log('new Function (with declare): ', global.foo) // => undefined
+  }
+}
+newFnWithDeclare()
+
+function newFnWithoutDeclare() {
+  var foo
+  var fn = new Function('foo = 1024')
+
+  fn()
+
+  console.log('new Function (without declare): ', foo) // => undefined
+  if (typeof window !== 'undefined') {
+    console.log('new Function (without declare): ', window.foo) // => 1024
+  } else if (typeof global !== 'undefined') {
+    console.log('new Function (without declare): ', global.foo) // => 1024
+  }
 }
 
-main()
+newFnWithoutDeclare()
+
+function thisOfStrictFunc() {
+  var sl = new Function('return this')
+  console.log('unStrict+unStrict this:', sl()) // => window or global
+
+  var st = new Function('"use strict"; return this')
+  // 严格模式下, 禁止 this 关键字执行全局对象!
+  console.log('unStrict+strict this:', st()) // => undefined
+}
+thisOfStrictFunc()
+
+function thisOfUnStrictFunc() {
+  'use strict'
+  var sl = new Function('return this')
+  // 不受当前作用域影响
+  console.log('strict+unStrict this:', sl()) // => window or global
+
+  var st = new Function('"use strict"; return this')
+  // 严格模式下, 禁止 this 关键字执行全局对象!
+  console.log('strict+strict this:', st()) //  => undefined
+}
+thisOfUnStrictFunc()

--- a/packages/demo/src/pages/eval/main.ts
+++ b/packages/demo/src/pages/eval/main.ts
@@ -1,0 +1,5 @@
+const main = () => {
+  console.log('hello eval')
+}
+
+main()

--- a/packages/demo/src/pages/index.html
+++ b/packages/demo/src/pages/index.html
@@ -1,0 +1,14 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <link rel="icon" type="image/svg+xml" href="/vite.svg" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>@lbd/demo</title>
+  </head>
+  <body>
+    <div id="app">
+      <a href="/eval/index.html">Eval with Function</a>
+    </div>
+  </body>
+</html>

--- a/packages/demo/tsconfig.app.json
+++ b/packages/demo/tsconfig.app.json
@@ -1,0 +1,14 @@
+{
+  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "types/*.d.ts"]
+}

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true
+  },
+  "files": [],
+  "references": [{ "path": "./tsconfig.app.json" }, { "path": "./tsconfig.node.json" }]
+}

--- a/packages/demo/tsconfig.node.json
+++ b/packages/demo/tsconfig.node.json
@@ -1,0 +1,24 @@
+{
+  "compilerOptions": {
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+    "noEmit": true,
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": false,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  },
+  "include": ["vite.config.ts"]
+}

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -5,23 +5,38 @@ import path from 'path'
 const mpaPrefix = 'src/pages'
 
 // 获取所有页面入口
-const pages = fs.readdirSync(path.resolve(__dirname, mpaPrefix))
+const pages = fs
+  .readdirSync(path.resolve(__dirname, mpaPrefix), {
+    withFileTypes: true,
+  })
+  .filter((dirent) => dirent.isDirectory())
 
 export default defineConfig((config) => {
+  const input = pages.reduce<Record<string, string>>(
+    (acc, page) => {
+      const { name } = page
+      acc[name] = path.resolve(__dirname, `${mpaPrefix}/${name}/index.html`)
+      return acc
+    },
+    {
+      index: path.resolve(__dirname, `${mpaPrefix}/index.html`),
+    },
+  )
+
+  console.log({ input })
+
   return {
     plugins: [],
     build: {
       rollupOptions: {
-        input: pages.reduce<Record<string, string>>((acc, page) => {
-          acc[page] = path.resolve(__dirname, `${mpaPrefix}/${page}/index.html`)
-          return acc
-        }, {}),
+        input,
       },
+      // 相对于项目根目录 (root)
       outDir: path.resolve(__dirname, 'dist'),
     },
-    base: './',
     // 指定项目根目录，避免了访问 MPA ，需要带上 src/pages
     root: mpaPrefix,
+    base: './',
     server: {
       port: 3000,
     },

--- a/packages/demo/vite.config.ts
+++ b/packages/demo/vite.config.ts
@@ -1,0 +1,29 @@
+import { defineConfig } from 'vite'
+import fs from 'fs'
+import path from 'path'
+
+const mpaPrefix = 'src/pages'
+
+// 获取所有页面入口
+const pages = fs.readdirSync(path.resolve(__dirname, mpaPrefix))
+
+export default defineConfig((config) => {
+  return {
+    plugins: [],
+    build: {
+      rollupOptions: {
+        input: pages.reduce<Record<string, string>>((acc, page) => {
+          acc[page] = path.resolve(__dirname, `${mpaPrefix}/${page}/index.html`)
+          return acc
+        }, {}),
+      },
+      outDir: path.resolve(__dirname, 'dist'),
+    },
+    base: './',
+    // 指定项目根目录，避免了访问 MPA ，需要带上 src/pages
+    root: mpaPrefix,
+    server: {
+      port: 3000,
+    },
+  }
+})


### PR DESCRIPTION
feat(demo): 添加 eval 页面并实现相关功能

- 在 eval 页面中添加了多个函数来演示 eval 的使用方法和行为
- 新增了 index.html 页面作为入口- 更新了 vite.config.ts 文件以支持多页面应用
- 添加了 .gitignore 文件以忽略不必要的文件和目录

feat: 添加 demo 包

- 创建 demo 包的目录结构和基本文件
- 添加 eval 页面的 HTML 和 TypeScript 文件
- 创建 demo 包的 package.json 和 tsconfig 文件
- 配置 demo包的 Vite 构建配置
- 更新根目录的 package.json 和 package-lock.json，添加 demo包为工作区