### PR TITLE
fix: npm postinstall 执行顺序

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,11 +9,11 @@
       "version": "1.0.0",
       "license": "ISC",
       "workspaces": [
+        "packages/utils",
         "packages/webpack-adv",
         "packages/vite-adv",
         "packages/demo",
-        "packages/ssr-adv",
-        "packages/utils"
+        "packages/ssr-adv"
       ],
       "devDependencies": {
         "prettier": "^3.5.3",
@@ -3969,7 +3969,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -3991,7 +3990,6 @@
       "os": [
         "darwin"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4013,7 +4011,6 @@
       "os": [
         "freebsd"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4035,7 +4032,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4057,7 +4053,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4079,7 +4074,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4101,7 +4095,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4123,7 +4116,6 @@
       "os": [
         "linux"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4145,7 +4137,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },
@@ -4167,7 +4158,6 @@
       "os": [
         "win32"
       ],
-      "peer": true,
       "engines": {
         "node": ">= 12.0.0"
       },

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
   "scripts": {
     "test": "npm run test --workspaces --if-present",
     "build": "npm run build --workspaces --if-present",
-    "postinstall": "npm run build"
+    "postinstall": "npm run build",
+    "clean:node_modules": "find . -type d -name 'node_modules' -exec rm -rf {} +",
+    "clean:dist": "npm run clean:dist --workspaces --if-present"
   },
   "repository": {
     "type": "git",
@@ -20,11 +22,11 @@
   },
   "homepage": "https://github.com/pengVc/learning-by-doing#readme",
   "workspaces": [
+    "packages/utils",
     "packages/webpack-adv",
     "packages/vite-adv",
     "packages/demo",
-    "packages/ssr-adv",
-    "packages/utils"
+    "packages/ssr-adv"
   ],
   "devDependencies": {
     "prettier": "^3.5.3",

--- a/packages/demo/package.json
+++ b/packages/demo/package.json
@@ -7,7 +7,8 @@
   },
   "scripts": {
     "dev": "vite",
-    "build": "vite build"
+    "build": "vite build",
+    "clean:dist": "rm -rf ./dist"
   },
   "keywords": [],
   "author": "",

--- a/packages/ssr-adv/package.json
+++ b/packages/ssr-adv/package.json
@@ -8,7 +8,8 @@
     "build": "npm run build:server && npm run build:client",
     "build:client": "vite build --outDir dist/client",
     "build:server": "vite build --ssr src/main.server.tsx --outDir dist/server",
-    "preview": "NODE_ENV=production tsx server.ts"
+    "preview": "NODE_ENV=production tsx server.ts",
+    "clean:dist": "rm -rf ./dist"
   },
   "devDependencies": {
     "@tailwindcss/vite": "^4.1.7",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -12,7 +12,8 @@
   "scripts": {
     "dev": "vite",
     "build": " tsc && vite build",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "clean:dist": "rm -rf ./dist"
   },
   "exports": {
     "types": "./dist/types/index.d.ts",

--- a/packages/vite-adv/package.json
+++ b/packages/vite-adv/package.json
@@ -6,7 +6,8 @@
   "scripts": {
     "dev": "vite --configLoader runner",
     "build": "vue-tsc -b && vite build --configLoader runner",
-    "preview": "vite preview  --configLoader runner"
+    "preview": "vite preview  --configLoader runner",
+    "clean:dist": "rm -rf ./dist"
   },
   "dependencies": {
     "vue": "^3.5.13"

--- a/packages/webpack-adv/package.json
+++ b/packages/webpack-adv/package.json
@@ -12,7 +12,8 @@
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --config webpack.config.ts",
     "build-ts-esm": "NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' webpack --config webpack.config.ts",
-    "build-tsx": "NODE_OPTIONS='--import tsx' webpack --config webpack.config.ts"
+    "build-tsx": "NODE_OPTIONS='--import tsx' webpack --config webpack.config.ts",
+    "clean:dist": "rm -rf ./dist"
   },
   "keywords": [],
   "author": "",


### PR DESCRIPTION
chore: 添加清理 dist 目录的脚本并调整工作区配置

- 在各个包的 package.json 中添加 clean:dist脚本，用于删除 dist 目录
- 在根目录 package.json 中添加 clean:node_modules 和 clean:dist 脚本
- 调整根目录 package.json 和 package-lock.json 中的工作区配置
- 移除 package-lock.json 中多个依赖的 peer 属性