### PR TITLE
refactor: monorepo tsconfig arch

### DIFF
--- a/packages/demo/tsconfig.app.json
+++ b/packages/demo/tsconfig.app.json
@@ -1,14 +1,12 @@
 {
-  "extends": "@vue/tsconfig/tsconfig.dom.json",
+  "extends": ["../../tsconfig.base.json", "@vue/tsconfig/tsconfig.dom.json"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
 
     /* Linting */
     "strict": true,
-    "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noFallthroughCasesInSwitch": true
   },
   "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.vue", "types/*.d.ts"]
 }

--- a/packages/demo/tsconfig.json
+++ b/packages/demo/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true
   },

--- a/packages/demo/tsconfig.node.json
+++ b/packages/demo/tsconfig.node.json
@@ -1,24 +1,10 @@
 {
+  "extends": ["../../tsconfig.base.node.json"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
 
     /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUnusedParameters": false
   },
   "include": ["vite.config.ts"]
 }

--- a/packages/ssr-adv/server.ts
+++ b/packages/ssr-adv/server.ts
@@ -6,7 +6,7 @@ import { fileURLToPath } from 'url'
 
 import { createServer } from 'vite'
 import sirv from 'sirv'
-import { getErrorMsg } from '@lbd/utils'
+import { getErrorMsg } from '@lbd/utils/lib'
 
 import type { SSRender } from './src/main.server.tsx'
 import type { ViteDevServer } from 'vite'

--- a/packages/ssr-adv/tsconfig.json
+++ b/packages/ssr-adv/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true
   },

--- a/packages/ssr-adv/tsconfig.node.json
+++ b/packages/ssr-adv/tsconfig.node.json
@@ -1,24 +1,8 @@
 {
+  "extends": ["../../tsconfig.base.node.json"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "jsx": "react",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "jsx": "react"
   },
   "files": ["vite.config.ts", "server.ts"]
 }

--- a/packages/utils/lib/getErrorMsg.ts
+++ b/packages/utils/lib/getErrorMsg.ts
@@ -1,5 +1,5 @@
-const getErrorMsg = (err: any): string => {
-  return err?.message ?? err?.msg ?? err?.toString() ?? 'Unknown error'
+const getErrorMsg = (err: any, fallback?: string): string => {
+  return err?.message ?? err?.msg ?? fallback ?? 'Unknown error'
 }
 
 export default getErrorMsg

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -8,7 +8,7 @@
   ],
   "main": "./dist/utils.umd.cjs",
   "module": "./dist/utils.js",
-  "types": "./dist/types/index.d.ts",
+  "types": "./dist/utils.d.ts",
   "scripts": {
     "dev": "vite",
     "build": " tsc && vite build",
@@ -16,9 +16,21 @@
     "clean:dist": "rm -rf ./dist"
   },
   "exports": {
-    "types": "./dist/types/index.d.ts",
-    "import": "./dist/utils.js",
-    "require": "./dist/utils.umd.cjs"
+    ".": {
+      "types": "./dist/utils.d.ts",
+      "import": "./dist/utils.js",
+      "require": "./dist/utils.umd.cjs"
+    },
+    "./lib": {
+      "types": "./dist/lib/index.d.ts",
+      "import": "./lib/index.ts",
+      "require": "./lib/index.ts"
+    },
+    "./lib/*": {
+      "types": "./dist/lib/*.d.ts",
+      "import": "./lib/*",
+      "require": "./lib/*"
+    }
   },
   "devDependencies": {
     "vite": "^6.3.1",

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -1,28 +1,13 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2020",
-    "useDefineForClassFields": true,
-    "module": "ESNext",
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.app.tsbuildinfo",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
-    "skipLibCheck": true,
     "declarationMap": true,
-    
+
     /* Bundler mode */
     "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "noEmit": true,
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noEmit": true
   },
   "include": ["src/**/*.ts", "lib/**/*.ts"],
   "references": [

--- a/packages/utils/tsconfig.json
+++ b/packages/utils/tsconfig.json
@@ -8,7 +8,8 @@
     "module": "ESNext",
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-
+    "declarationMap": true,
+    
     /* Bundler mode */
     "moduleResolution": "bundler",
     "allowImportingTsExtensions": true,

--- a/packages/utils/tsconfig.node.json
+++ b/packages/utils/tsconfig.node.json
@@ -1,24 +1,8 @@
 {
+  "extends": ["../../tsconfig.base.node.json"],
   "compilerOptions": {
     "composite": true,
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
-
-    /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
-    "jsx": "react",
-
-    /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": true,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo"
   },
   "files": ["vite.config.ts"]
 }

--- a/packages/utils/vite.config.ts
+++ b/packages/utils/vite.config.ts
@@ -14,8 +14,8 @@ export default defineConfig({
     {
       ...dts({
         tsconfigPath: './tsconfig.json',
-        outDir: './dist/types',
-        entryRoot: 'lib',
+        outDir: './dist',
+        insertTypesEntry: true,
       }),
       apply: (_, env) => {
         return env.command === 'build'

--- a/packages/vite-adv/tsconfig.json
+++ b/packages/vite-adv/tsconfig.json
@@ -1,5 +1,4 @@
 {
-  "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true
   },

--- a/packages/vite-adv/tsconfig.node.json
+++ b/packages/vite-adv/tsconfig.node.json
@@ -1,24 +1,13 @@
 {
+  "extends": ["../../tsconfig.base.node.json"],
   "compilerOptions": {
     "tsBuildInfoFile": "./node_modules/.tmp/tsconfig.node.tsbuildinfo",
-    "target": "ES2022",
-    "lib": ["ES2023"],
-    "module": "ESNext",
-    "skipLibCheck": true,
 
     /* Bundler mode */
-    "moduleResolution": "bundler",
-    "allowImportingTsExtensions": true,
-    "isolatedModules": true,
-    "moduleDetection": "force",
     "noEmit": true,
 
     /* Linting */
-    "strict": true,
-    "noUnusedLocals": true,
-    "noUnusedParameters": false,
-    "noFallthroughCasesInSwitch": true,
-    "noUncheckedSideEffectImports": true
+    "noUnusedParameters": false
   },
   "include": ["vite.config.ts", "plugins/**/*.ts"]
 }

--- a/packages/webpack-adv/package.json
+++ b/packages/webpack-adv/package.json
@@ -11,6 +11,7 @@
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
     "build": "webpack --config webpack.config.ts",
+    "build-ts-cjs": "webpack --config webpack.config.ts",
     "build-ts-esm": "NODE_OPTIONS='--no-warnings=ExperimentalWarning --loader ts-node/esm' webpack --config webpack.config.ts",
     "build-tsx": "NODE_OPTIONS='--import tsx' webpack --config webpack.config.ts",
     "clean:dist": "rm -rf ./dist"

--- a/packages/webpack-adv/plugins/hooks-practise-plugin.ts
+++ b/packages/webpack-adv/plugins/hooks-practise-plugin.ts
@@ -1,6 +1,4 @@
 import type { Compiler, WebpackPluginInstance } from 'webpack'
-import * as fs from 'node:fs/promises'
-import * as path from 'node:path'
 
 // 自定义 Webpack 插件类
 class HooksPractisePlugin implements WebpackPluginInstance {

--- a/packages/webpack-adv/tsconfig-esm.json
+++ b/packages/webpack-adv/tsconfig-esm.json
@@ -2,16 +2,14 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "esModuleInterop": true,
     "baseUrl": "./",
     "outDir": "dist",
     "target": "es2016",
-    "module": "commonjs",
+    "module": "ESNext",
+    "skipLibCheck": true,
+    "moduleResolution": "bundler",
+    "isolatedModules": true,
+    "moduleDetection": "force",
     "declarationMap": true
-  },
-  "ts-node": {
-    "compilerOptions": {
-      "module": "CommonJS"
-    }
   }
 }

--- a/packages/webpack-adv/tsconfig-esm.json
+++ b/packages/webpack-adv/tsconfig-esm.json
@@ -1,15 +1,9 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "composite": true,
-    "baseUrl": "./",
     "outDir": "dist",
-    "target": "es2016",
-    "module": "ESNext",
-    "skipLibCheck": true,
     "moduleResolution": "bundler",
-    "isolatedModules": true,
-    "moduleDetection": "force",
+    "declaration": true,
     "declarationMap": true
   }
 }

--- a/packages/webpack-adv/tsconfig.json
+++ b/packages/webpack-adv/tsconfig.json
@@ -2,11 +2,9 @@
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
     "composite": true,
-    "esModuleInterop": true,
-    "baseUrl": "./",
     "outDir": "dist",
-    "target": "es2016",
     "module": "commonjs",
+    "declaration": true,
     "declarationMap": true
   },
   "ts-node": {

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,111 +1,113 @@
 {
   "compilerOptions": {
-    /* Visit https://aka.ms/tsconfig to read more about this file */
+    /* 访问 https://aka.ms/tsconfig 阅读更多关于此文件的信息 */
 
-    /* Projects */
-    // "incremental": true,                              /* Save .tsbuildinfo files to allow for incremental compilation of projects. */
-    // "composite": true                                 /* Enable constraints that allow a TypeScript project to be used with project references. */,
-    // "tsBuildInfoFile": "./.tsbuildinfo",              /* Specify the path to .tsbuildinfo incremental compilation file. */
-    // "disableSourceOfProjectReferenceRedirect": true,  /* Disable preferring source files instead of declaration files when referencing composite projects. */
-    // "disableSolutionSearching": true,                 /* Opt a project out of multi-project reference checking when editing. */
-    // "disableReferencedProjectLoad": true,             /* Reduce the number of projects loaded automatically by TypeScript. */
+    /* 项目配置 (Projects) */
+    // "incremental": true,                              /* 启用增量编译，保存 .tsbuildinfo 文件 */
+    "composite": true /* 启用组合项目支持，允许使用项目引用 */,
+    // "tsBuildInfoFile": "./.tsbuildinfo",              /* 指定 .tsbuildinfo 增量编译文件路径 */
+    // "disableSourceOfProjectReferenceRedirect": true,  /* 禁止在引用组合项目时优先使用源文件而不是声明文件 */
+    // "disableSolutionSearching": true,                 /* 编辑时排除多项目引用检查 */
+    // "disableReferencedProjectLoad": true,             /* 减少 TypeScript 自动加载的项目数量 */
 
-    /* Language and Environment */
-    "target": "ES2019" /* Set the JavaScript language version for emitted JavaScript and include compatible library declarations. */,
-    // "lib": [],                                        /* Specify a set of bundled library declaration files that describe the target runtime environment. */
-    // "jsx": "preserve",                                /* Specify what JSX code is generated. */
-    // "libReplacement": true,    x`x````                       /* Enable lib replacement. */
-    // "experimentalDecorators": true,                   /* Enable experimental support for legacy experimental decorators. */
-    // "emitDecoratorMetadata": true,                    /* Emit design-type metadata for decorated declarations in source files. */
-    // "jsxFactory": "",                                 /* Specify the JSX factory function used when targeting React JSX emit, e.g. 'React.createElement' or 'h'. */
-    // "jsxFragmentFactory": "",                         /* Specify the JSX Fragment reference used for fragments when targeting React JSX emit e.g. 'React.Fragment' or 'Fragment'. */
-    // "jsxImportSource": "",                            /* Specify module specifier used to import the JSX factory functions when using 'jsx: react-jsx*'. */
-    // "reactNamespace": "",                             /* Specify the object invoked for 'createElement'. This only applies when targeting 'react' JSX emit. */
-    // "noLib": true,                                    /* Disable including any library files, including the default lib.d.ts. */
-    // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
-    // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
+    /* 语言和环境配置 (Language and Environment) */
+    "target": "es2016" /* 设置生成的 JavaScript 版本以及包含的库声明 */,
+    // "lib": [],                                        /* 指定目标运行环境的库声明文件 */
+    // "jsx": "preserve",                                /* 指定生成的 JSX 代码类型 */
+    // "libReplacement": true,                           /* 启用 lib 替换 */
+    // "experimentalDecorators": true,                   /* 启用实验性装饰器支持 */
+    // "emitDecoratorMetadata": true,                    /* 为源文件中的装饰声明生成元数据 */
+    // "jsxFactory": "",                                 /* 指定 React JSX 生成的工厂函数 */
+    // "jsxFragmentFactory": "",                         /* 指定 React JSX Fragment 引用 */
+    // "jsxImportSource": "",                            /* 指定导入 JSX 工厂函数的模块 */
+    // "reactNamespace": "",                             /* 指定 'createElement' 调用的对象 */
+    // "noLib": true,                                    /* 禁止包含任何库文件 */
+    "useDefineForClassFields": true /* 生成符合 ECMAScript 标准的类字段 */,
+    "moduleDetection": "force" /* 控制检测模块格式的方法 */,
 
-    /* Modules */
-    "baseUrl": "." /* Specify the base directory to resolve non-relative module names. */,
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
-    // "paths": {}                                       /* Specify a set of entries that re-map imports to additional lookup locations. */,
-    // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */
-    "typeRoots": ["./node_modules/@types"] /* Specify multiple folders that act like './node_modules/@types'. */,
-    // "types": [],                                      /* Specify type package names to be included without being referenced in a source file. */
-    // "allowUmdGlobalAccess": true,                     /* Allow accessing UMD globals from modules. */
-    // "moduleSuffixes": [],                             /* List of file name suffixes to search when resolving a module. */
-    // "allowImportingTsExtensions": true,               /* Allow imports to include TypeScript file extensions. Requires '--moduleResolution bundler' and either '--noEmit' or '--emitDeclarationOnly' to be set. */
-    // "rewriteRelativeImportExtensions": true,          /* Rewrite '.ts', '.tsx', '.mts', and '.cts' file extensions in relative import paths to their JavaScript equivalent in output files. */
-    // "resolvePackageJsonExports": true,                /* Use the package.json 'exports' field when resolving package imports. */
-    // "resolvePackageJsonImports": true,                /* Use the package.json 'imports' field when resolving imports. */
-    // "customConditions": [],                           /* Conditions to set in addition to the resolver-specific defaults when resolving imports. */
-    // "noUncheckedSideEffectImports": true,             /* Check side effect imports. */
-    // "resolveJsonModule": true,                        /* Enable importing .json files. */
-    // "allowArbitraryExtensions": true,                 /* Enable importing files with any extension, provided a declaration file is present. */
-    // "noResolve": true,                                /* Disallow 'import's, 'require's or '<reference>'s from expanding the number of files TypeScript should add to a project. */
+    /* 模块配置 (Modules) */
+    "module": "ESNext" /* 指定生成的模块代码类型 */,
+    // "rootDir": "./",                                  /* 指定源文件根目录 */
+    // "moduleResolution": "node10",                     /* 指定模块解析方式 */
+    // "baseUrl": "./",                                  /* 指定非相对模块名解析的基础目录 */
+    // "paths": {},                                      /* 指定重新映射导入路径 */
+    // "rootDirs": [],                                   /* 允许将多个目录视为一个目录进行模块解析 */
+    // "typeRoots": [],                                  /* 指定 '@types' 类型定义文件的查找目录 */
+    // "types": [],                                      /* 指定无需引用即可包含的类型包名称 */
+    // "allowUmdGlobalAccess": true,                     /* 允许从模块访问 UMD 全局变量 */
+    // "moduleSuffixes": [],                             /* 解析模块时搜索的文件后缀列表 */
+    // "allowImportingTsExtensions": true,               /* 允许导入包含 TypeScript 扩展名的文件 */
+    // "rewriteRelativeImportExtensions": true,          /* 将相对导入路径中的 '.ts', '.tsx' 等扩展名重写为 JavaScript 扩展名 */
+    // "resolvePackageJsonExports": true,                /* 使用 package.json 的 'exports' 字段解析包导入 */
+    // "resolvePackageJsonImports": true,                /* 使用 package.json 的 'imports' 字段解析导入 */
+    // "customConditions": [],                           /* 在解析导入时设置的额外条件 */
+    "noUncheckedSideEffectImports": true /* 检查副作用导入 */,
+    // "resolveJsonModule": true,                        /* 启用导入 .json 文件 */
+    // "allowArbitraryExtensions": true,                 /* 启用导入任意扩展名文件（需有声明文件） */
+    // "noResolve": true,                                /* 禁止扩展导入、require 或 reference 的文件数量 */
 
-    /* JavaScript Support */
-    // "allowJs": true,                                  /* Allow JavaScript files to be a part of your program. Use the 'checkJS' option to get errors from these files. */
-    // "checkJs": true,                                  /* Enable error reporting in type-checked JavaScript files. */
-    // "maxNodeModuleJsDepth": 1,                        /* Specify the maximum folder depth used for checking JavaScript files from 'node_modules'. Only applicable with 'allowJs'. */
+    /* JavaScript 支持 */
+    // "allowJs": true,                                  /* 允许 JavaScript 文件参与编译 */
+    // "checkJs": true,                                  /* 启用 JavaScript 文件的错误报告 */
+    // "maxNodeModuleJsDepth": 1,                        /* 指定检查 node_modules 中 JS 文件的最大深度 */
 
-    /* Emit */
-    // "declaration": true,                              /* Generate .d.ts files from TypeScript and JavaScript files in your project. */
-    // "declarationMap": true,                           /* Create sourcemaps for d.ts files. */
-    // "emitDeclarationOnly": true,                      /* Only output d.ts files and not JavaScript files. */
-    // "sourceMap": true,                                /* Create source map files for emitted JavaScript files. */
-    // "inlineSourceMap": true,                          /* Include sourcemap files inside the emitted JavaScript. */
-    // "noEmit": true,                                   /* Disable emitting files from a compilation. */
-    // "outFile": "./",                                  /* Specify a file that bundles all outputs into one JavaScript file. If 'declaration' is true, also designates a file that bundles all .d.ts output. */
-    // "outDir": "./",                                   /* Specify an output folder for all emitted files. */
-    // "removeComments": true,                           /* Disable emitting comments. */
-    // "importHelpers": true,                            /* Allow importing helper functions from tslib once per project, instead of including them per-file. */
-    // "downlevelIteration": true,                       /* Emit more compliant, but verbose and less performant JavaScript for iteration. */
-    // "sourceRoot": "",                                 /* Specify the root path for debuggers to find the reference source code. */
-    // "mapRoot": "",                                    /* Specify the location where debugger should locate map files instead of generated locations. */
-    // "inlineSources": true,                            /* Include source code in the sourcemaps inside the emitted JavaScript. */
-    // "emitBOM": true,                                  /* Emit a UTF-8 Byte Order Mark (BOM) in the beginning of output files. */
-    // "newLine": "crlf",                                /* Set the newline character for emitting files. */
-    // "stripInternal": true,                            /* Disable emitting declarations that have '@internal' in their JSDoc comments. */
-    // "noEmitHelpers": true,                            /* Disable generating custom helper functions like '__extends' in compiled output. */
-    // "noEmitOnError": true,                            /* Disable emitting files if any type checking errors are reported. */
-    // "preserveConstEnums": true,                       /* Disable erasing 'const enum' declarations in generated code. */
-    // "declarationDir": "./",                           /* Specify the output directory for generated declaration files. */
+    /* 输出配置 */
+    // "declaration": true,                              /* 生成 .d.ts 类型声明文件 */
+    // "declarationMap": true,                           /* 为 d.ts 文件生成 source map */
+    // "emitDeclarationOnly": true,                      /* 只输出 d.ts 文件，不输出 JavaScript 文件 */
+    // "sourceMap": true,                                /* 为生成的 JavaScript 文件创建 source map */
+    // "inlineSourceMap": true,                          /* 将 source map 内嵌到生成的 JavaScript 中 */
+    // "noEmit": true,                                   /* 禁止生成输出文件 */
+    // "outFile": "./",                                  /* 指定输出 JavaScript 文件的合并路径 */
+    // "outDir": "./",                                   /* 指定所有输出文件的输出目录 */
+    // "removeComments": true,                           /* 不生成注释 */
+    // "importHelpers": true,                            /* 从 tslib 导入辅助函数，避免重复生成 */
+    // "downlevelIteration": true,                       /* 生成更兼容但性能较差的迭代代码 */
+    // "sourceRoot": "",                                 /* 指定调试器查找源代码的根路径 */
+    // "mapRoot": "",                                    /* 指定调试器查找 map 文件的位置 */
+    // "inlineSources": true,                            /* 将源代码内嵌到 sourcemaps 中 */
+    // "emitBOM": true,                                  /* 在输出文件开头添加 UTF-8 BOM */
+    // "newLine": "crlf",                                /* 设置生成文件的换行符 */
+    // "stripInternal": true,                            /* 不生成带有 '@internal' 注释的声明 */
+    // "noEmitHelpers": true,                            /* 不生成 '__extends' 等辅助函数 */
+    // "noEmitOnError": true,                            /* 如果存在类型错误，则不生成文件 */
+    // "preserveConstEnums": true,                       /* 保留 'const enum' 声明 */
+    // "declarationDir": "./",                           /* 指定生成的声明文件输出目录 */
 
-    /* Interop Constraints */
-    // "isolatedModules": true,                          /* Ensure that each file can be safely transpiled without relying on other imports. */
-    // "verbatimModuleSyntax": true,                     /* Do not transform or elide any imports or exports not marked as type-only, ensuring they are written in the output file's format based on the 'module' setting. */
-    // "isolatedDeclarations": true,                     /* Require sufficient annotation on exports so other tools can trivially generate declaration files. */
-    // "erasableSyntaxOnly": true,                       /* Do not allow runtime constructs that are not part of ECMAScript. */
-    "allowSyntheticDefaultImports": true /* Allow 'import x from y' when a module doesn't have a default export. */,
-    "esModuleInterop": true /* Emit additional JavaScript to ease support for importing CommonJS modules. This enables 'allowSyntheticDefaultImports' for type compatibility. */,
-    // "preserveSymlinks": true,                         /* Disable resolving symlinks to their realpath. This correlates to the same flag in node. */
-    "forceConsistentCasingInFileNames": true /* Ensure that casing is correct in imports. */,
+    /* 互操作约束 (Interop Constraints) */
+    "isolatedModules": true /* 确保每个文件可以独立转译 */,
+    // "verbatimModuleSyntax": true,                     /* 不转换或省略未标记为 type-only 的导入/导出 */
+    // "isolatedDeclarations": true,                     /* 要求导出有足够的注解以便其他工具生成声明文件 */
+    // "erasableSyntaxOnly": true,                       /* 不允许非 ECMAScript 的运行时构造 */
+    // "allowSyntheticDefaultImports": true,             /* 当模块没有默认导出时允许 'import x from y' */
+    "esModuleInterop": true /* 启用对 CommonJS 模块的默认导入支持 */,
+    // "preserveSymlinks": true,                         /* 不解析符号链接的真实路径 */
+    "forceConsistentCasingInFileNames": true /* 确保导入路径的大小写正确 */,
 
-    /* Type Checking */
-    "strict": true /* Enable all strict type-checking options. */,
-    // "noImplicitAny": true,                            /* Enable error reporting for expressions and declarations with an implied 'any' type. */
-    // "strictNullChecks": true,                         /* When type checking, take into account 'null' and 'undefined'. */
-    // "strictFunctionTypes": true,                      /* When assigning functions, check to ensure parameters and the return values are subtype-compatible. */
-    // "strictBindCallApply": true,                      /* Check that the arguments for 'bind', 'call', and 'apply' methods match the original function. */
-    // "strictPropertyInitialization": true,             /* Check for class properties that are declared but not set in the constructor. */
-    // "strictBuiltinIteratorReturn": true,              /* Built-in iterators are instantiated with a 'TReturn' type of 'undefined' instead of 'any'. */
-    // "noImplicitThis": true,                           /* Enable error reporting when 'this' is given the type 'any'. */
-    // "useUnknownInCatchVariables": true,               /* Default catch clause variables as 'unknown' instead of 'any'. */
-    // "alwaysStrict": true,                             /* Ensure 'use strict' is always emitted. */
-    // "noUnusedLocals": true,                           /* Enable error reporting when local variables aren't read. */
-    // "noUnusedParameters": true,                       /* Raise an error when a function parameter isn't read. */
-    // "exactOptionalPropertyTypes": true,               /* Interpret optional property types as written, rather than adding 'undefined'. */
-    // "noImplicitReturns": true,                        /* Enable error reporting for codepaths that do not explicitly return in a function. */
-    // "noFallthroughCasesInSwitch": true,               /* Enable error reporting for fallthrough cases in switch statements. */
-    // "noUncheckedIndexedAccess": true,                 /* Add 'undefined' to a type when accessed using an index. */
-    // "noImplicitOverride": true,                       /* Ensure overriding members in derived classes are marked with an override modifier. */
-    // "noPropertyAccessFromIndexSignature": true,       /* Enforces using indexed accessors for keys declared using an indexed type. */
-    // "allowUnusedLabels": true,                        /* Disable error reporting for unused labels. */
-    // "allowUnreachableCode": true,                     /* Disable error reporting for unreachable code. */
+    /* 类型检查 (Type Checking) */
+    "strict": true /* 启用所有严格类型检查选项 */,
+    // "noImplicitAny": true,                            /* 报告隐式 'any' 类型的表达式和声明 */
+    // "strictNullChecks": true,                         /* 类型检查时考虑 'null' 和 'undefined' */
+    // "strictFunctionTypes": true,                      /* 分配函数时检查参数和返回值是否兼容 */
+    // "strictBindCallApply": true,                      /* 检查 'bind', 'call', 'apply' 方法的参数是否匹配 */
+    // "strictPropertyInitialization": true,             /* 检查类属性是否在构造函数中初始化 */
+    // "strictBuiltinIteratorReturn": true,              /* 内置迭代器的 TReturn 类型为 undefined */
+    // "noImplicitThis": true,                           /* 报告 'this' 类型为 'any' 的情况 */
+    // "useUnknownInCatchVariables": true,               /* 默认 catch 变量为 'unknown' 类型 */
+    // "alwaysStrict": true,                             /* 确保始终生成 'use strict' */
+    "noUnusedLocals": true /* 报告未使用的局部变量 */,
+    // "noUnusedParameters": true /* 报告未使用的函数参数 */,
+    // "exactOptionalPropertyTypes": true,               /* 按照原意解释可选属性类型 */
+    // "noImplicitReturns": true,                        /* 报告函数中未显式返回的情况 */
+    // "noFallthroughCasesInSwitch": true,               /* 报告 switch 语句中的穿透情况 */
+    // "noUncheckedIndexedAccess": true,                 /* 使用索引访问时自动添加 'undefined' 类型 */
+    // "noImplicitOverride": true,                       /* 确保派生类中覆盖成员使用 override 修饰符 */
+    // "noPropertyAccessFromIndexSignature": true,       /* 强制使用索引访问器访问索引类型键 */
+    // "allowUnusedLabels": true,                        /* 禁用未使用标签的错误报告 */
+    // "allowUnreachableCode": true,                     /* 禁用不可达代码的错误报告 */
 
-    /* Completeness */
-    // "skipDefaultLibCheck": true,                      /* Skip type checking .d.ts files that are included with TypeScript. */
-    "skipLibCheck": true /* Skip type checking all .d.ts files. */
+    /* 完整性 (Completeness) */
+    // "skipDefaultLibCheck": true,                      /* 跳过 TypeScript 默认库文件的类型检查 */
+    "skipLibCheck": true /* 跳过所有 .d.ts 文件的类型检查 */
   }
 }

--- a/tsconfig.base.node.json
+++ b/tsconfig.base.node.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "composite": true,
+    "target": "ES2022",
+    "lib": ["ES2023"],
+    "module": "ESNext",
+    "skipLibCheck": true,
+
+    /* Bundler mode */
+    "moduleResolution": "bundler",
+    "allowImportingTsExtensions": true,
+    "isolatedModules": true,
+    "moduleDetection": "force",
+
+    /* Linting */
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noFallthroughCasesInSwitch": true,
+    "noUncheckedSideEffectImports": true
+  }
+}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,10 @@
 {
-  "extends": "./tsconfig.base.json",
+  "files": [],
+  "include": [],
+  "compilerOptions": {
+    "disableSolutionSearching": true,
+    "disableReferencedProjectLoad": true
+  },
   "references": [
     { "path": "./packages/webpack-adv" },
     { "path": "./packages/vite-adv" },


### PR DESCRIPTION
[build:重构 TypeScript 配置](https://github.com/pengVc/learning-by-doing/commit/47e692219199426e7897fbe777f804285729b629) 

- 更新 tsconfig.app.json, tsconfig.json, tsconfig.node.json 等多个配置文件
- 调整编译选项以提高代码质量和性能
- 移除未使用的配置项
- 新增 tsconfig.base.node.json 作为 Node.js 项目的公共配置

[refactor(utils): 重构 utils包的类型定义和模块导出](https://github.com/pengVc/learning-by-doing/commit/9df8f6c02e3c12355a16e14ce750452a85679ae4) 

- 更新 getErrorMsg 函数签名，增加 fallback 参数
- 修改 package.json 中的类型定义路径
- 更新 tsconfig.json 和 vite.config.ts 中的类型输出配置
- 新增 tsconfig-esm.json 配置 ESM 模块